### PR TITLE
Add 'Open path in Terminal' for OSX

### DIFF
--- a/lib/show-in-system.coffee
+++ b/lib/show-in-system.coffee
@@ -1,38 +1,52 @@
 {$} = require 'atom'
 shell = require 'shell'
+p = require 'path'
+exec = require("child_process").exec
 
 module.exports =
-  # Register open and show commnads
+  # Register open, show and terminal commnads
   activate: ->
+    atom.workspaceView.command 'show-in-system:terminal', (event) =>
+      @terminal(@getView(event.target))
     atom.workspaceView.command 'show-in-system:show', (event) =>
       @show(@getView(event.target))
     atom.workspaceView.command 'show-in-system:open', (event) =>
       @open(@getView(event.target))
-  
+
   # Cleanup
   deactivate: ->
     atom.workspaceView.off 'show-in-system:show'
     atom.workspaceView.off 'show-in-system:open'
-  
+    atom.workspaceView.off 'show-in-system:terminal'
+
   # Call native/shell open item in folder method for the given view.
   show: (view) ->
     path = @getPath(view)
     if !path
       console.warn('Show in system: Path not found. File not saved?')
     shell.showItemInFolder(path) if path
-  
+
   # Call native/shell open item method for the given view.
   open: (view) ->
     path = @getPath(view)
     if !path
       console.warn('Show in system: Path not found. File not saved?')
     shell.openItem(path) if path
-  
+
+  terminal: (view) ->
+    path = @getPath(view)
+    dir = p.dirname(path) if path
+    if !path
+      console.warn('Show in system: Path not found. File not saved?')
+    if !dir
+      console.warn('Show in system: Directory not found. File not saved?')
+    exec "open -a Terminal.app #{dir}" if path && dir
+
   # Get (all) parent view(s) with class type file, directory OR tab.
   # The first one will be our selected item...
   getView: (node) ->
     return $(node).parents('.file, .directory, .tab').view()
-  
+
   # Extract the path from the view (item). Supports view elements from
   # the tree-view and the tab-view module.
   getPath: (view) ->
@@ -44,4 +58,4 @@ module.exports =
       return view.item.getPath()
     else
       console.error('Show in system: Unexpected view type!')
-  
+

--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -2,6 +2,8 @@
   '.platform-darwin .tree-view':
     'Show in Finder': 'show-in-system:show'
     'Open with Finder': 'show-in-system:open'
+    'Open path in Terminal': 'show-in-system:terminal'
   '.platform-darwin .tab':
     'Show in Finder': 'show-in-system:show'
     'Open with Finder': 'show-in-system:open'
+    'Open path in Terminal': 'show-in-system:terminal'

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "main": "./lib/show-in-system",
   "version": "0.2.0",
   "description": "atom.io package to show and open files or directories in the system file manager",
-  "activationEvents": ["show-in-system:show", "show-in-system:open"],
+  "activationEvents": ["show-in-system:show", "show-in-system:open", "show-in-system:terminal"],
   "repository": "https://github.com/jerolimov/atom-show-in-system",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
I added an 'Open path in Terminal' context entry for OSX users. It would be simple enough to add for other OS's, I just didn't have them available to me at the time.

<img src="http://i.imgur.com/r4bob65.png"/>
