### PR TITLE
Conform to current API

### DIFF
--- a/lib/show-in-system.coffee
+++ b/lib/show-in-system.coffee
@@ -1,6 +1,7 @@
 {$} = require 'atom'
 shell = require 'shell'
 child_process = require 'child_process'
+{CompositeDisposable} = require 'event-kit'
 
 module.exports =
   configDefaults: {
@@ -10,54 +11,37 @@ module.exports =
 
   # Register open, show and terminal commnads
   activate: ->
-    atom.workspaceView.command 'show-in-system:show', (event) =>
-      @show(@getView(event.target))
-    atom.workspaceView.command 'show-in-system:open', (event) =>
-      @open(@getView(event.target))
-    atom.workspaceView.command 'show-in-system:terminal', (event) =>
-      @terminal(@getView(event.target))
+    @disposables = new CompositeDisposable
+    @disposables.add atom.commands.add('.tab, .tree-view .selected', {
+      'show-in-system:show': (event) => @show(event.currentTarget)
+      'show-in-system:open': (event) => @open(event.currentTarget)
+      'show-in-system:terminal': (event) => @terminal(event.currentTarget)
+    })
 
   # Cleanup
-  deactivate: ->
-    atom.workspaceView.off 'show-in-system:show'
-    atom.workspaceView.off 'show-in-system:open'
-    atom.workspaceView.off 'show-in-system:terminal'
+  deactivate: -> @disposables.dispose()
 
   # Call native/shell open item in folder method for the given view.
-  show: (view) ->
-    path = @getPath(view)
+  show: (target) ->
+    path = @getPath(target)
     if !path
       console.warn('Show in system: Path not found. File not saved?')
     shell.showItemInFolder(path) if path
 
   # Call native/shell open item method for the given view.
-  open: (view) ->
-    path = @getPath(view)
+  open: (target) ->
+    path = @getPath(target)
     if !path
       console.warn('Show in system: Path not found. File not saved?')
     shell.openItem(path) if path
 
-  terminal: (view) ->
-    path = @getPath(view)
+  terminal: (target) ->
+    path = @getPath(target)
     if !path
       console.warn('Show in system: Path not found. File not saved?')
     app = atom.config.get('show-in-system.app')
     args = atom.config.get('show-in-system.args')
-    child_process.exec "open -a #{app} #{args} #{path}" if path
+    child_process.exec "#{app} #{args} #{path}" if path
 
-  # Get (all) parent view(s) with class type file, directory OR tab.
-  # The first one will be our selected item...
-  getView: (node) ->
-    return $(node).parents('.file, .directory, .tab').view()
-
-  # Extract the path from the view (item). Supports view elements from
-  # the tree-view and the tab-view module.
-  getPath: (view) ->
-    if !view or !view.length
-      console.error('Show in system: View not found!')
-    else if view.is('.file') || view.is('.directory')
-      return view.getPath()
-    else if view.is('.tab')
-      return view.item.getPath()
-    else
-      console.error('Show in system: Unexpected view type!')
+  # Extract the path from the target: can be a tree-view or tab item.
+  getPath: (target) -> return target.getPath?() ? target.item?.getPath()

--- a/package.json
+++ b/package.json
@@ -10,5 +10,6 @@
     "atom": ">0.60.0"
   },
   "dependencies": {
+    "event-kit": "^1.0.0"
   }
 }


### PR DESCRIPTION
Directly accessing Views is discouraged in the current Atom API,
but its now easy to get paths via model objects.

Right now the package is totally inoperative without my changes.
Please apply and release as 0.3.1!

fixes jerolimov/atom-show-in-system#6
